### PR TITLE
Use RangeBounds as input

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -18,7 +16,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.0.0
+          - 1.28.0
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,3 @@ categories = ["text-processing", "parsing", "algorithms", "no-std"]
 readme = "README.md"
 repository = "https://github.com/Anders429/substring"
 exclude = [".github/*"]
-
-[build-dependencies]
-autocfg = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ categories = ["text-processing", "parsing", "algorithms", "no-std"]
 readme = "README.md"
 repository = "https://github.com/Anders429/substring"
 exclude = [".github/*"]
+
+[dev-dependencies]
+more_ranges = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov.io](https://img.shields.io/codecov/c/gh/Anders429/substring)](https://codecov.io/gh/Anders429/substring)
 [![crates.io](https://img.shields.io/crates/v/substring)](https://crates.io/crates/substring)
 [![docs.rs](https://docs.rs/substring/badge.svg)](https://docs.rs/substring)
-[![MSRV](https://img.shields.io/badge/rustc-1.0.0+-yellow.svg)](#minimum-supported-rust-version)
+[![MSRV](https://img.shields.io/badge/rustc-1.28.0+-yellow.svg)](#minimum-supported-rust-version)
 [![License](https://img.shields.io/crates/l/substring)](#license)
 
 Substring method for string types.
@@ -23,7 +23,7 @@ your string types.
 ```rust
 use substring::Substring;
 
-assert_eq!("hello, world!".substring(7, 12), "world");
+assert_eq!("hello, world!".substring(7..12), "world");
 ```
 
 Note that the indexing of substrings is based on
@@ -33,8 +33,8 @@ substrings may not always match your intuition:
 ```rust
 use substring::Substring;
 
-assert_eq!("ã".substring(0, 1), "a");  // As opposed to "ã".
-assert_eq!("ã".substring(1, 2), "\u{0303}")
+assert_eq!("ã".substring(0..1), "a");  // As opposed to "ã".
+assert_eq!("ã".substring(1..2), "\u{0303}")
 ```
 
 The above example occurs because "ã" is technically made up of two UTF-8 scalar values: the letter
@@ -48,7 +48,7 @@ complexity *O(n)*, where *n* is the byte length of the string. This is due to ch
 of predictible byte lengths.
 
 ## Minimum Supported Rust Version
-This crate is guaranteed to compile on stable `rustc 1.0.0` and up.
+This crate is guaranteed to compile on stable `rustc 1.28.0` and up.
 
 ## License
 This project is licensed under either of

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,0 @@
-extern crate autocfg;
-
-fn main() {
-    let ac = autocfg::new();
-    ac.emit_rustc_version(1, 6);
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,10 @@
 //! use substring::Substring;
 //!
 //! // Works on a string slice.
-//! assert_eq!("foobar".substring(2,5), "oba");
+//! assert_eq!("foobar".substring(2..5), "oba");
 //!
 //! // Also works on a String.
-//! assert_eq!("foobar".to_string().substring(1,6), "oobar");
+//! assert_eq!("foobar".to_string().substring(1..6), "oobar");
 //! ```
 //!
 //! As Rust strings are UTF-8 encoded, the algorithm for finding a character substring is `O(n)`,
@@ -28,8 +28,8 @@
 //! ```
 //! use substring::Substring;
 //!
-//! assert_eq!("ã".substring(0, 1), "a");  // As opposed to "ã".
-//! assert_eq!("ã".substring(1, 2), "\u{0303}")
+//! assert_eq!("ã".substring(0..1), "a");  // As opposed to "ã".
+//! assert_eq!("ã".substring(1..2), "\u{0303}")
 //! ```
 //!
 //! The above example occurs because "ã" is technically made up of two UTF-8 scalar values.
@@ -49,6 +49,11 @@
 #[cfg(not(rustc_1_6))]
 extern crate std as core;
 
+use core::ops::{
+    Bound::{Excluded, Included, Unbounded},
+    RangeBounds,
+};
+
 /// Provides a [`substring()`] method.
 ///
 /// The [`substring()`] method obtains a string slice of characters within the range specified by
@@ -60,7 +65,7 @@ pub trait Substring {
     /// `start_index` and `end_index`.
     ///
     /// The range specified is a character range, not a byte range.
-    fn substring(&self, start_index: usize, end_index: usize) -> &str;
+    fn substring<I: RangeBounds<usize>>(&self, index: I) -> &str;
 }
 
 /// Implements a [`substring()`] method for [`str`].
@@ -81,28 +86,34 @@ impl Substring for str {
     /// ```
     /// use substring::Substring;
     ///
-    /// assert_eq!("foobar".substring(2,5), "oba");
+    /// assert_eq!("foobar".substring(2..5), "oba");
     /// ```
     #[must_use]
-    fn substring(&self, start_index: usize, end_index: usize) -> &str {
-        if end_index <= start_index {
+    fn substring<I: RangeBounds<usize>>(&self, index: I) -> &str {
+        let len = self.len();
+        let start = match index.start_bound() {
+            Excluded(&start) => start.saturating_add(1),
+            Included(&start) => start,
+            Unbounded => 0,
+        };
+        let end = match index.end_bound() {
+            Excluded(&end) => end,
+            Included(&end) => end.saturating_add(1),
+            Unbounded => len,
+        };
+        if end <= start {
             return "";
         }
-
-        let mut indices = self.char_indices();
-
-        let obtain_index = |(index, _char)| index;
-        let str_len = self.len();
+        let mut indices = self.char_indices().map(|(i, _c)| i);
 
         unsafe {
             // SAFETY: Since `indices` iterates over the `CharIndices` of `self`, we can guarantee
             // that the indices obtained from it will always be within the bounds of `self` and they
+            // will always lie on UTF-8 sequence boundaries.// SAFETY: Since `indices` iterates over the `CharIndices` of `self`, we can guarantee
+            // that the indices obtained from it will always be within the bounds of `self` and they
             // will always lie on UTF-8 sequence boundaries.
-            self.slice_unchecked(
-                indices.nth(start_index).map_or(str_len, &obtain_index),
-                indices
-                    .nth(end_index - start_index - 1)
-                    .map_or(str_len, &obtain_index),
+            self.get_unchecked(
+                indices.nth(start).unwrap_or(len)..indices.nth(end - start - 1).unwrap_or(len),
             )
         }
     }
@@ -114,27 +125,27 @@ mod tests {
 
     #[test]
     fn test_substring() {
-        assert_eq!("foobar".substring(0, 3), "foo");
+        assert_eq!("foobar".substring(0..3), "foo");
     }
 
     #[test]
     fn test_out_of_bounds() {
-        assert_eq!("foobar".substring(0, 10), "foobar");
-        assert_eq!("foobar".substring(6, 10), "");
+        assert_eq!("foobar".substring(0..10), "foobar");
+        assert_eq!("foobar".substring(6..10), "");
     }
 
     #[test]
     fn test_start_less_than_end() {
-        assert_eq!("foobar".substring(3, 2), "");
+        assert_eq!("foobar".substring(3..2), "");
     }
 
     #[test]
     fn test_start_and_end_equal() {
-        assert_eq!("foobar".substring(3, 3), "");
+        assert_eq!("foobar".substring(3..3), "");
     }
 
     #[test]
     fn test_multiple_byte_characters() {
-        assert_eq!("fõøbα®".substring(2, 5), "øbα");
+        assert_eq!("fõøbα®".substring(2..5), "øbα");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,32 +155,35 @@ mod tests {
     fn test_unbounded() {
         assert_eq!("foobar".substring(..), "foobar");
     }
-    
+
     #[test]
     fn test_unbounded_start() {
         assert_eq!("foobar".substring(..3), "foo");
     }
-    
+
     #[test]
     fn test_unbounded_end() {
         assert_eq!("foobar".substring(3..), "bar");
     }
-    
+
     #[test]
     fn test_exclusive_start() {
-        assert_eq!("foobar".substring(RangeFromExclusive {start: 3}), "ar");
+        assert_eq!("foobar".substring(RangeFromExclusive { start: 3 }), "ar");
     }
-    
+
     #[test]
     fn test_exclusive_start_max() {
-        assert_eq!("foobar".substring(RangeFromExclusive {start: usize::MAX}), "");
+        assert_eq!(
+            "foobar".substring(RangeFromExclusive { start: usize::MAX }),
+            ""
+        );
     }
-    
+
     #[test]
     fn test_inclusive_end() {
         assert_eq!("foobar".substring(..=3), "foob");
     }
-    
+
     #[test]
     fn test_inclusive_end_max() {
         assert_eq!("foobar".substring(..=usize::MAX), "foobar");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,10 +44,7 @@
 // Since the MSRV is 1.0.0, allowing usage of deprecated items is ok, as the replacements are likely
 // not available in early versions.
 #![allow(deprecated)]
-#![cfg_attr(rustc_1_6, no_std)]
-
-#[cfg(not(rustc_1_6))]
-extern crate std as core;
+#![no_std]
 
 use core::ops::{
     Bound::{Excluded, Included, Unbounded},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,9 @@
 #![allow(deprecated)]
 #![no_std]
 
+#[cfg(test)]
+extern crate more_ranges;
+
 use core::ops::{
     Bound::{Excluded, Included, Unbounded},
     RangeBounds,
@@ -118,6 +121,8 @@ impl Substring for str {
 
 #[cfg(test)]
 mod tests {
+    use core::usize;
+    use more_ranges::RangeFromExclusive;
     use Substring;
 
     #[test]
@@ -144,5 +149,40 @@ mod tests {
     #[test]
     fn test_multiple_byte_characters() {
         assert_eq!("fõøbα®".substring(2..5), "øbα");
+    }
+
+    #[test]
+    fn test_unbounded() {
+        assert_eq!("foobar".substring(..), "foobar");
+    }
+    
+    #[test]
+    fn test_unbounded_start() {
+        assert_eq!("foobar".substring(..3), "foo");
+    }
+    
+    #[test]
+    fn test_unbounded_end() {
+        assert_eq!("foobar".substring(3..), "bar");
+    }
+    
+    #[test]
+    fn test_exclusive_start() {
+        assert_eq!("foobar".substring(RangeFromExclusive {start: 3}), "ar");
+    }
+    
+    #[test]
+    fn test_exclusive_start_max() {
+        assert_eq!("foobar".substring(RangeFromExclusive {start: usize::MAX}), "");
+    }
+    
+    #[test]
+    fn test_inclusive_end() {
+        assert_eq!("foobar".substring(..=3), "foob");
+    }
+    
+    #[test]
+    fn test_inclusive_end_max() {
+        assert_eq!("foobar".substring(..=usize::MAX), "foobar");
     }
 }


### PR DESCRIPTION
Fixes #9. This PR changes to allow values implementing the `RangeBounds<usize>` trait to be used as parameters for `substring()`. This allows for more flexibility and clarity at call sites.